### PR TITLE
Add a Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.1)
+    method_source (0.8.2)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    slop (3.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
The only gem in use is pry, but most Ruby devs expect to
see one and install from it to be sure they get the right
versions of every gem that's used. Even if it's not a big
issue, it increases other developers' confidence that they
have the right gems when they can clone a repo and then 
"bundle install" and "bundle exec <command>" to be sure they're
loading the right gems when they run the code
